### PR TITLE
some minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ mvn clean package
 
 This will generate a shaded JAR that can be picked up by the following steps.
 
+Downloading the OTel agent jar
+
+```shell
+wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar
+```
+
 For the OTel agent, it will need to be manually copied into the `target/` directory, like this:
 
 ```shell

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,12 +10,12 @@ services:
       - "14250"
   # Collector
   otel-collector:
-    image: otel/opentelemetry-collector:latest
+    image: otel/opentelemetry-collector
     command: ["--config=/etc/otel-collector-config.yaml"]
     volumes:
       - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
     ports:
-      - "13133:13133" # Health_check extension
+      - "13133:13133" # health_check extension
       - "4317:4317"   # OTLP gRPC receiver
       - "55681:55681" # OTLP HTTP receiver alternative port
     depends_on:
@@ -26,16 +26,24 @@ services:
     image: fish_demo:latest
     ports:
       - "8083:8083"
+    depends_on:
+      - otel-collector
+
   # Mustelid service
   mustelid-service:
     image: mustelid_demo:latest
     ports:
       - "8084:8084"
+    depends_on:
+      - otel-collector
   # Feline service
   feline-service:
     image: feline_demo:latest
     ports:
       - "8085:8085"
+    depends_on:
+      - otel-collector
+
   # Mammal service
   mammal-service:
     image: mammal_demo:latest

--- a/deploy/otel-collector-config.yaml
+++ b/deploy/otel-collector-config.yaml
@@ -9,7 +9,8 @@ exporters:
 
   jaeger:
     endpoint: jaeger-all-in-one:14250
-    insecure: true
+    tls:
+      insecure: true
 
 processors:
   batch:

--- a/make.sh
+++ b/make.sh
@@ -1,13 +1,18 @@
-#This Docker file helps to run a animal service
+#This make file builds the docker images locally
 
 #To build a package
+mvn clean package
 
-mvn package
+# Get the Otel agent jar
+wget https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/latest/download/opentelemetry-javaagent.jar && mv opentelemetry-javaagent.jar target/
 
 #To build a image
-
-docker build -t animalservice
+docker build -t animals_demo -f src/main/docker/animal/Dockerfile target/
+docker build -t feline_demo -f src/main/docker/feline/Dockerfile target/
+docker build -t fish_demo -f src/main/docker/fish/Dockerfile target/
+docker build -t mammal_demo -f src/main/docker/mammal/Dockerfile target/
+docker build -t mustelid_demo -f src/main/docker/mustelid/Dockerfile target/
 
 #List a images
+docker images "*demo"
 
-docker images


### PR DESCRIPTION
I have added the option to download the OTel Jar via wget. Not sure if a set of commands for different platforms is also required at this point. The benefit though is that the make.sh will also download and mv it to the target directory before making the docker images.